### PR TITLE
propogate eval order

### DIFF
--- a/aiger_analysis/abc.py
+++ b/aiger_analysis/abc.py
@@ -6,7 +6,7 @@ import aiger
 from aiger_analysis.common import extract_aig
 
 
-def simplify(e):
+def simplify(e, verbose=False):
     # avoids confusion and guarantees deletion on exit
     with tempfile.TemporaryDirectory() as tmpdirname:
         aag_name = os.path.join(tmpdirname, 'input.aag')
@@ -14,10 +14,9 @@ def simplify(e):
         circ.write(aag_name)
         aig_name = os.path.join(tmpdirname, 'input.aig')
         call(['aigtoaig', aag_name, aig_name])
-        call(['abc',
-              '-c',
-              f'read {aig_name}; dc2; dc2; dc2; write_aiger -s {aig_name}']  # noqa
-             , stdout=PIPE  # comment this line to see more output
-            )
+        command = ['abc',
+                   '-c',
+                   f'read {aig_name}; dc2; dc2; dc2; write_aiger -s {aig_name}']  # noqa
+        call(command) if verbose else call(command, stdout=PIPE)
         call(['aigtoaig', aig_name, aag_name])
         return aiger.parser.load(aag_name)

--- a/aiger_analysis/abc.py
+++ b/aiger_analysis/abc.py
@@ -10,13 +10,14 @@ def simplify(e):
     # avoids confusion and guarantees deletion on exit
     with tempfile.TemporaryDirectory() as tmpdirname:
         aag_name = os.path.join(tmpdirname, 'input.aag')
-        extract_aig(e).write(aag_name)
+        circ = e if isinstance(e, aiger.AIG) else extract_aig(e)
+        circ.write(aag_name)
         aig_name = os.path.join(tmpdirname, 'input.aig')
         call(['aigtoaig', aag_name, aig_name])
         call(['abc',
               '-c',
-              f'read {aig_name}; print_stats; dc2; dc2; dc2; print_stats; write {aig_name}']  # noqa
-            # , stdout=PIPE  # comment this line to see more output
+              f'read {aig_name}; dc2; dc2; dc2; write_aiger -s {aig_name}']  # noqa
+             , stdout=PIPE  # comment this line to see more output
             )
         call(['aigtoaig', aig_name, aag_name])
         return aiger.parser.load(aag_name)

--- a/aiger_analysis/analysis.py
+++ b/aiger_analysis/analysis.py
@@ -3,12 +3,12 @@ This module provides basic operations on aig circuits, such as
 satisfiability queries, model counting, and quantifier elimination.
 """
 
+import aiger
 import funcy as fn
 from bidict import bidict
-
-import aiger
 from pysat.formula import CNF
 from pysat.solvers import Lingeling
+
 import aiger_analysis.common as cmn
 
 
@@ -29,7 +29,7 @@ def _tseitin(e):
 
     true_var = None  # Reserved variable name for constant True
 
-    for gate in fn.cat(aig._eval_order):
+    for gate in cmn.eval_order(aig):
         if isinstance(gate, aiger.aig.ConstFalse):
             if true_var is None:
                 true_var = fresh_var()

--- a/aiger_analysis/common.py
+++ b/aiger_analysis/common.py
@@ -1,6 +1,30 @@
+from collections import defaultdict
+
+import funcy as fn
 from aiger import AIG, BoolExpr
 from aigerbv.aigbv import AIGBV
 from aigerbv.expr import SignedBVExpr, UnsignedBVExpr
+from toposort import toposort
+
+
+def _dependency_graph(nodes):
+    queue, deps, visited = list(nodes), defaultdict(set), set()
+    while queue:
+        node = queue.pop()
+        if node in visited:
+            continue
+        else:
+            visited.add(node)
+
+        children = node.children
+        queue.extend(children)
+        deps[node].update(children)
+
+    return deps
+
+
+def eval_order(circ):
+    return fn.lcat(toposort(_dependency_graph(circ.cones | circ.latch_cones)))
 
 
 def extract_aig(e):

--- a/aiger_analysis/count.py
+++ b/aiger_analysis/count.py
@@ -1,6 +1,8 @@
 import aiger
 import funcy as fn
 
+import aiger_analysis.common as cmn
+
 try:
     from dd.cudd import BDD
 except ImportError:
@@ -23,7 +25,7 @@ def to_bdd(circ, output):
     bdd.declare(*input_refs_to_var.values())
 
     gate_nodes = {}
-    for gate in fn.cat(circ._eval_order):
+    for gate in cmn.eval_order(circ):
         if isinstance(gate, aiger.aig.ConstFalse):
             gate_nodes[gate] = bdd.add_expr('False')
         elif isinstance(gate, aiger.aig.Inverter):

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest-flake8==0.9 # pyup: ignore
 pytest-sugar==0.9.1 # pyup: ignore
 pytest-xdist==1.22.5 # pyup: ignore
 python-sat==0.1.3.dev16
+toposort==1.5

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'funcy',
         'dd',
         'python-sat',
+        'toposort',
     ],
     packages=find_packages(),
     zip_safe=False,


### PR DESCRIPTION
`AIG._eval_order` was an internal method in `AIG` that is being removed from `py-aiger` since it is unnecessary and to simplifies the code base. I've moved it to py-aiger-analysis since its useful for building bdds and going to CNF.