### PR TITLE
Fix from_bdd for cudd

### DIFF
--- a/aiger_analysis/bdd.py
+++ b/aiger_analysis/bdd.py
@@ -91,5 +91,7 @@ def _parse_bddexpr(ite_str: str):
     return BDDExprVisitor().visit(BDDEXPR_GRAMMAR.parse(ite_str))
 
 
-def from_bdd(bdd_func):
+def from_bdd(bdd_func, manager=None):
+    if manager:
+        return _parse_bddexpr(manager.to_expr(bdd_func))
     return _parse_bddexpr(bdd_func.to_expr())


### PR DESCRIPTION
The [dd cudd interface](https://github.com/tulip-control/dd/blob/master/dd/cudd.pyx) does not have a to_expr() method for dd.cudd.Function objects. It only has to_expr for managers. 

Previous version raised errors, this is a simple workaround.